### PR TITLE
Fixed problem with line choosing if r_int was part of a comment block

### DIFF
--- a/gybote/gybote.py
+++ b/gybote/gybote.py
@@ -66,6 +66,8 @@ def choose_line():
             if line[0] != COMMENT_CHAR:
                 log.info('pointer = %s, rInt = %s, num_of_lines = %s ', pointer, r_int, num_of_lines)
                 return line
+            else:
+                iteration()
         # just to be safe or something?
         elif pointer > num_of_lines:
             line = ""
@@ -103,7 +105,6 @@ def main():
 
     while True:
         iteration()
-       
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
See commit message.... new iteration whenever line chosen is within a comment block. The problem was that first lines after large chunks of comments would be chosen more often than other lines because of the way that a new line was chosen after finding a commented line.
